### PR TITLE
Added Cistern.ValueLinq performance tests

### DIFF
--- a/src/PushStream6.PerformanceTest/PushStream6.PerformanceTest.fsproj
+++ b/src/PushStream6.PerformanceTest/PushStream6.PerformanceTest.fsproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="Cistern.ValueLinq" Version="0.1.14" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Not particularly relevant to the discussion, but whilst adding these tests it was noticed that for some reason PushStream performed particularly poorly on my machine, yet this more complex code somehow managed to performant. Strange.

```
BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19042.1348 (20H2/October2020Update)
Intel Core i7 CPU 930 2.80GHz (Nehalem), 1 CPU, 8 logical and 4 physical cores
.NET SDK=6.0.100
  [Host]    : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT DEBUG
  RyuJitX64 : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT

Job=RyuJitX64  Jit=RyuJit  Platform=X64

|             Method |       Mean |     Error |    StdDev | Ratio | RatioSD |   Gen 0 |   Gen 1 | Allocated |
|------------------- |-----------:|----------:|----------:|------:|--------:|--------:|--------:|----------:|
|           Baseline |   8.322 us | 0.0539 us | 0.0504 us |  1.00 |    0.00 |       - |       - |         - |
|               Linq | 219.770 us | 3.3350 us | 2.6037 us | 26.42 |    0.30 |       - |       - |     400 B |
|          ValueLinq | 131.284 us | 1.3040 us | 1.0889 us | 15.78 |    0.20 |       - |       - |     193 B |
|      ValueLinqFast |  33.163 us | 0.1335 us | 0.1115 us |  3.99 |    0.02 |       - |       - |         - |
|              Array | 238.232 us | 0.3656 us | 0.3420 us | 28.63 |    0.19 | 64.6973 | 12.6953 | 272,865 B |
|                Seq | 437.430 us | 2.9104 us | 2.7224 us | 52.56 |    0.39 |       - |       - |     480 B |
|         PushStream |  54.294 us | 0.0314 us | 0.0262 us |  6.52 |    0.04 |       - |       - |     168 B |
|   FasterPushStream |  87.352 us | 0.5204 us | 0.4868 us | 10.50 |    0.09 |       - |       - |         - |
|       PushStreamV2 | 227.553 us | 0.0649 us | 0.0607 us | 27.34 |    0.17 |       - |       - |     216 B |
| FasterPushStreamV2 |  87.042 us | 0.3577 us | 0.3346 us | 10.46 |    0.07 |       - |       - |         - |
```

